### PR TITLE
Reduce amount of payload attached to destination unreachable packets

### DIFF
--- a/src/main/kotlin/com/jasonernst/kanonproxy/KAnonProxy.kt
+++ b/src/main/kotlin/com/jasonernst/kanonproxy/KAnonProxy.kt
@@ -21,6 +21,7 @@ import com.jasonernst.knet.network.ip.v6.Ipv6Header
 import com.jasonernst.knet.network.nextheader.IcmpNextHeaderWrapper
 import com.jasonernst.knet.transport.TransportHeader
 import com.jasonernst.knet.transport.tcp.TcpHeader
+import com.jasonernst.knet.transport.tcp.options.TcpOptionMaximumSegmentSize
 import com.jasonernst.knet.transport.udp.UdpHeader
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -175,6 +176,12 @@ class KAnonProxy(
                         is Ipv6Header -> IcmpV6DestinationUnreachableCodes.ADDRESS_UNREACHABLE
                         else -> throw IllegalArgumentException("Unknown IP protocol: " + ipHeader::class.java.simpleName)
                     }
+                val mtu =
+                    if (ipHeader is Ipv4Header) {
+                        TcpOptionMaximumSegmentSize.defaultIpv4MSS
+                    } else {
+                        TcpOptionMaximumSegmentSize.defaultIpv6MSS
+                    }
                 val response =
                     IcmpFactory.createDestinationUnreachable(
                         code,
@@ -184,6 +191,7 @@ class KAnonProxy(
                         ipHeader,
                         transportHeader,
                         payload,
+                        mtu.toInt(),
                     )
                 outgoingQueue.add(response)
                 return

--- a/src/main/kotlin/com/jasonernst/kanonproxy/icmp/IcmpFactory.kt
+++ b/src/main/kotlin/com/jasonernst/kanonproxy/icmp/IcmpFactory.kt
@@ -4,6 +4,7 @@ import com.jasonernst.icmp.common.IcmpType
 import com.jasonernst.icmp.common.PacketHeaderException
 import com.jasonernst.icmp.common.v4.IcmpV4DestinationUnreachableCodes
 import com.jasonernst.icmp.common.v4.IcmpV4DestinationUnreachablePacket
+import com.jasonernst.icmp.common.v4.IcmpV4DestinationUnreachablePacket.Companion.DESTINATION_UNREACHABLE_HEADER_MIN_LENGTH
 import com.jasonernst.icmp.common.v6.IcmpV6DestinationUnreachableCodes
 import com.jasonernst.icmp.common.v6.IcmpV6DestinationUnreachablePacket
 import com.jasonernst.knet.Packet
@@ -11,6 +12,7 @@ import com.jasonernst.knet.network.ip.IpHeader
 import com.jasonernst.knet.network.ip.IpType
 import com.jasonernst.knet.network.ip.v4.Ipv4Header
 import com.jasonernst.knet.network.ip.v6.Ipv6Header
+import com.jasonernst.knet.network.ip.v6.Ipv6Header.Companion.IP6_HEADER_SIZE
 import com.jasonernst.knet.network.nextheader.IcmpNextHeaderWrapper
 import com.jasonernst.knet.transport.TransportHeader
 import java.net.Inet6Address
@@ -38,6 +40,8 @@ object IcmpFactory {
         sourceAddress: InetAddress,
         ipHeader: IpHeader,
         transportHeader: TransportHeader,
+        payload: ByteArray,
+        mtu: Int,
     ): Packet {
         val protocol =
             when (ipHeader) {
@@ -51,9 +55,20 @@ object IcmpFactory {
         val originalRequestBuffer = ByteBuffer.allocate(ipHeader.getTotalLength().toInt())
         originalRequestBuffer.put(ipHeader.toByteArray())
 
-        val originalTransportBuffer = transportHeader.toByteArray()
-        val reducedTransportBuffer = ByteArray(8) // RFC792 and RFC4443 say to include the first 64-bits of anything after the IP header
-        System.arraycopy(originalTransportBuffer, 0, reducedTransportBuffer, 0, 8)
+        val originalTransportBufferAndPayloadBuffer = ByteBuffer.allocate(ipHeader.getPayloadLength().toInt())
+        originalTransportBufferAndPayloadBuffer.put(transportHeader.toByteArray())
+        originalTransportBufferAndPayloadBuffer.put(payload)
+
+        val limit =
+            if (ipHeader is Ipv4Header) {
+                8 // rfc792 says to include the first 64-bits of the transport header
+            } else {
+                // rfc4443 says to include as much as possible without going over the min MTU
+                // IPv6 header length, ICMPv6 destination unreachble min header length, IPv6 header length (the one that generated this to happen)
+                (mtu.toUInt() - IP6_HEADER_SIZE - DESTINATION_UNREACHABLE_HEADER_MIN_LENGTH - IP6_HEADER_SIZE).toInt()
+            }
+        val reducedTransportBuffer = ByteArray(limit)
+        System.arraycopy(originalTransportBufferAndPayloadBuffer.array(), 0, reducedTransportBuffer, 0, limit)
         originalRequestBuffer.put(reducedTransportBuffer)
         originalRequestBuffer.rewind()
 


### PR DESCRIPTION
When the anon proxy is not able to make an outbound connection, it generates and ICMP destination unreachable packet.

Previously, we attached the entire transport header and payload to the ICMP packet, however, this may cause the packet to exceed the MTU of the link, and it is not in spec with RFC 792: https://www.rfc-editor.org/rfc/rfc792.txt which states it should include `Internet Header + 64 bits of Original Data Datagram`

For ICMPv6, the RFC4443 spec https://datatracker.ietf.org/doc/html/rfc4443#section-3.1 says to include `As much of invoking packet as possible without the ICMPv6 packet exceeding the minimum IPv6 MTU`