### PR TITLE
Made simulteanous sessions no long block each other

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,11 +3,11 @@ icmp = "1.0.0"
 jupiter = "5.11.3"
 kotlin = "2.0.21"
 kotlinter = "4.4.1"
-knet = "0.1.1"
+knet = "0.1.2"
 logback-classic = "1.5.12"
 mockk = "1.13.13"
 slf4j = "2.0.16"
-testservers = "0.0.1"
+testservers = "0.0.2"
 
 [libraries]
 icmp_linux = { module = "com.jasonernst.icmp:icmp_linux", version.ref = "icmp" }

--- a/src/main/kotlin/com/jasonernst/kanonproxy/KAnonProxy.kt
+++ b/src/main/kotlin/com/jasonernst/kanonproxy/KAnonProxy.kt
@@ -362,6 +362,7 @@ class KAnonProxy(
     }
 
     override fun removeSession(session: Session) {
+        logger.debug("Removing session: {}", session)
         sessionTableBySessionKey.remove(session.getKey())
     }
 }

--- a/src/main/kotlin/com/jasonernst/kanonproxy/Session.kt
+++ b/src/main/kotlin/com/jasonernst/kanonproxy/Session.kt
@@ -3,26 +3,41 @@ package com.jasonernst.kanonproxy
 import com.jasonernst.kanonproxy.tcp.AnonymousTcpSession
 import com.jasonernst.kanonproxy.udp.UdpSession
 import com.jasonernst.knet.Packet
+import com.jasonernst.knet.SentinelPacket
+import com.jasonernst.knet.network.ip.IpHeader
 import com.jasonernst.knet.network.ip.IpType
+import com.jasonernst.knet.transport.TransportHeader
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import java.net.InetAddress
 import java.nio.ByteBuffer
 import java.nio.channels.ByteChannel
 import java.util.concurrent.LinkedBlockingDeque
+import java.util.concurrent.atomic.AtomicBoolean
 
 abstract class Session(
-    val sourceAddress: InetAddress,
-    val sourcePort: UShort,
-    val destinationAddress: InetAddress,
-    val destinationPort: UShort,
-    val protocol: UByte,
+    var initialIpHeader: IpHeader?,
+    var initialTransportHeader: TransportHeader?,
+    var initialPayload: ByteArray?,
     val returnQueue: LinkedBlockingDeque<Packet>,
     val protector: VpnProtector,
+    val sessionManager: SessionManager,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
     abstract val channel: ByteChannel
     private val readBuffer = ByteBuffer.allocate(DEFAULT_BUFFER_SIZE)
     var lastHeard = System.currentTimeMillis()
+    private val outgoingJob = SupervisorJob() // https://stackoverflow.com/a/63407811
+    protected val outgoingScope = CoroutineScope(Dispatchers.IO + outgoingJob)
+
+    val incomingQueue = LinkedBlockingDeque<Packet>()
+    private val incomingJob = SupervisorJob()
+    private val incomingScope = CoroutineScope(Dispatchers.IO + incomingJob)
+    private val isRunning = AtomicBoolean(false)
 
     companion object {
         fun getKey(
@@ -37,20 +52,19 @@ abstract class Session(
          * Depending on the protocol, returns either a UDP or TCP session
          */
         fun getSession(
-            sourceIp: InetAddress,
-            sourcePort: UShort,
-            destinationIp: InetAddress,
-            destinationPort: UShort,
-            protocol: UByte,
+            initialIPHeader: IpHeader,
+            initialTransportHeader: TransportHeader,
+            initialPayload: ByteArray,
             returnQueue: LinkedBlockingDeque<Packet>,
             protector: VpnProtector,
+            sessionManager: SessionManager,
         ): Session =
-            when (protocol) {
+            when (initialIPHeader.protocol) {
                 IpType.UDP.value -> {
-                    UdpSession(sourceIp, sourcePort, destinationIp, destinationPort, returnQueue, protector)
+                    UdpSession(initialIPHeader, initialTransportHeader, initialPayload, returnQueue, protector, sessionManager)
                 }
                 IpType.TCP.value -> {
-                    AnonymousTcpSession(sourceIp, sourcePort, destinationIp, destinationPort, returnQueue, protector)
+                    AnonymousTcpSession(initialIPHeader, initialTransportHeader, initialPayload, returnQueue, protector, sessionManager)
                 }
                 else -> {
                     throw IllegalArgumentException("Unsupported protocol for session")
@@ -58,13 +72,12 @@ abstract class Session(
             }
     }
 
-    fun getKey(): String = getKey(sourceAddress, sourcePort, destinationAddress, destinationPort, protocol)
+    fun getKey(): String = getKey(getSourceAddress(), getSourcePort(), getDestinationAddress(), getDestinationPort(), getProtocol())
 
     override fun toString(): String =
-        "Session(sourceAddress='$sourceAddress', sourcePort=$sourcePort, destinationAddress='$destinationAddress', destinationPort=$destinationPort, protocol=$protocol)"
+        "Session(sourceAddress='${getSourceAddress()}', sourcePort=${getSourcePort()}, destinationAddress='${getDestinationAddress()}', destinationPort=${getDestinationPort()}, protocol=${getProtocol()})"
 
     open fun handleReturnTrafficLoop(): Int {
-        // logger.debug("Waiting for return traffic on {}", this)
         val len = channel.read(readBuffer)
         if (len > 0) {
             lastHeard = System.currentTimeMillis()
@@ -78,5 +91,61 @@ abstract class Session(
         return len
     }
 
+    /**
+     * Should be called after the connection to the remote side is established. This will start the loop that reads
+     * from the incoming queue and handles each packet. Until this point, packets will just build up here. This is to
+     * prevent us from responding with an ACK before the connection is established.
+     */
+    fun startIncomingHandling() {
+        if (isRunning.get()) {
+            logger.warn("Incoming handling already started")
+            return
+        }
+        isRunning.set(true)
+        incomingScope.launch {
+            while (isRunning.get()) {
+                val packet = incomingQueue.take()
+                if (packet is SentinelPacket) {
+                    logger.debug("Received sentinel packet, stopping session")
+                    isRunning.set(false)
+                    break
+                }
+                handlePacketFromClient(packet)
+            }
+        }
+    }
+
     abstract fun handlePayloadFromInternet(payload: ByteArray)
+
+    abstract fun handlePacketFromClient(packet: Packet)
+
+    open fun getSourceAddress(): InetAddress = initialIpHeader?.sourceAddress ?: throw IllegalArgumentException("No source address")
+
+    open fun getDestinationAddress(): InetAddress =
+        initialIpHeader?.destinationAddress ?: throw IllegalArgumentException("No destination address")
+
+    open fun getSourcePort(): UShort = initialTransportHeader?.sourcePort ?: throw IllegalArgumentException("No source port")
+
+    open fun getDestinationPort(): UShort = initialTransportHeader?.destinationPort ?: throw IllegalArgumentException("No destination port")
+
+    open fun getProtocol(): UByte = initialIpHeader?.protocol ?: throw IllegalArgumentException("No protocol")
+
+    open fun close() {
+        logger.debug("Closing session")
+        if (channel.isOpen) {
+            try {
+                channel.close()
+            } catch (e: Exception) {
+                logger.error("Failed to close channel", e)
+            }
+        }
+        isRunning.set(false)
+        incomingQueue.add(SentinelPacket)
+        runBlocking {
+            outgoingJob.cancel()
+            incomingJob.cancel()
+        }
+        logger.debug("Session closed")
+        sessionManager.removeSession(this)
+    }
 }

--- a/src/main/kotlin/com/jasonernst/kanonproxy/Session.kt
+++ b/src/main/kotlin/com/jasonernst/kanonproxy/Session.kt
@@ -103,6 +103,7 @@ abstract class Session(
         }
         isRunning.set(true)
         incomingScope.launch {
+            Thread.currentThread().name = "Incoming handler: ${getKey()}"
             while (isRunning.get()) {
                 val packet = incomingQueue.take()
                 if (packet is SentinelPacket) {

--- a/src/main/kotlin/com/jasonernst/kanonproxy/SessionManager.kt
+++ b/src/main/kotlin/com/jasonernst/kanonproxy/SessionManager.kt
@@ -1,0 +1,5 @@
+package com.jasonernst.kanonproxy
+
+interface SessionManager {
+    fun removeSession(session: Session)
+}

--- a/src/main/kotlin/com/jasonernst/kanonproxy/icmp/IcmpFactory.kt
+++ b/src/main/kotlin/com/jasonernst/kanonproxy/icmp/IcmpFactory.kt
@@ -16,7 +16,6 @@ import com.jasonernst.knet.network.ip.v6.Ipv6Header
 import com.jasonernst.knet.network.ip.v6.Ipv6Header.Companion.IP6_HEADER_SIZE
 import com.jasonernst.knet.network.nextheader.IcmpNextHeaderWrapper
 import com.jasonernst.knet.transport.TransportHeader
-import com.jasonernst.packetdumper.stringdumper.StringPacketDumper
 import org.slf4j.LoggerFactory
 import java.net.Inet6Address
 import java.net.InetAddress
@@ -81,9 +80,6 @@ object IcmpFactory {
         modifiedOriginalRequestBuffer.put(ipHeader.toByteArray())
         modifiedOriginalRequestBuffer.put(reducedTransportBuffer)
         modifiedOriginalRequestBuffer.rewind()
-
-        val stringPacketDumper = StringPacketDumper(logger)
-        stringPacketDumper.dumpBuffer(modifiedOriginalRequestBuffer)
 
         val icmpHeader =
             when (ipHeader) {

--- a/src/main/kotlin/com/jasonernst/kanonproxy/tcp/AnonymousTcpSession.kt
+++ b/src/main/kotlin/com/jasonernst/kanonproxy/tcp/AnonymousTcpSession.kt
@@ -1,34 +1,40 @@
 package com.jasonernst.kanonproxy.tcp
 
+import com.jasonernst.icmp.common.v4.IcmpV4DestinationUnreachableCodes
+import com.jasonernst.icmp.common.v6.IcmpV6DestinationUnreachableCodes
+import com.jasonernst.kanonproxy.SessionManager
 import com.jasonernst.kanonproxy.VpnProtector
+import com.jasonernst.kanonproxy.icmp.IcmpFactory
 import com.jasonernst.knet.Packet
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import com.jasonernst.knet.network.ip.IpHeader
+import com.jasonernst.knet.transport.TransportHeader
+import com.jasonernst.knet.transport.tcp.TcpHeader
+import com.jasonernst.knet.transport.tcp.options.TcpOptionMaximumSegmentSize
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
-import java.net.InetAddress
+import java.net.Inet4Address
 import java.net.InetSocketAddress
 import java.nio.channels.SocketChannel
 import java.util.concurrent.LinkedBlockingDeque
 
 class AnonymousTcpSession(
-    sourceAddress: InetAddress,
-    sourcePort: UShort,
-    destinationAddress: InetAddress,
-    destinationPort: UShort,
+    initialIpHeader: IpHeader,
+    initialTransportHeader: TransportHeader,
+    initialPayload: ByteArray,
     returnQueue: LinkedBlockingDeque<Packet>,
     protector: VpnProtector,
+    sessionManager: SessionManager,
 ) : TcpSession(
-        sourceAddress = sourceAddress,
-        sourcePort = sourcePort,
-        destinationAddress = destinationAddress,
-        destinationPort = destinationPort,
+        initialIpHeader = initialIpHeader,
+        initialTransportHeader = initialTransportHeader,
+        initialPayload = initialPayload,
         returnQueue = returnQueue,
         protector = protector,
+        sessionManager = sessionManager,
     ) {
     private val logger = LoggerFactory.getLogger(javaClass)
-    override val tcpStateMachine: TcpStateMachine = TcpStateMachine(MutableStateFlow(TcpState.LISTEN), mtu, this)
+    override val tcpStateMachine: TcpStateMachine = TcpStateMachine(MutableStateFlow(TcpState.LISTEN), mtu(), this)
 
     // note: android doesn't suppor the open function with the protocol family, so just open like this and assume
     // that connect will take care of it. If it doesn't we can fall back to open with the InetSocketAddress, however,
@@ -43,15 +49,60 @@ class AnonymousTcpSession(
         return len
     }
 
+    override fun handlePacketFromClient(packet: Packet) {
+        val responsePackets = tcpStateMachine.processHeaders(packet.ipHeader!!, packet.nextHeaders!! as TcpHeader, packet.payload!!)
+        for (response in responsePackets) {
+            returnQueue.put(packet)
+        }
+        if (tcpStateMachine.tcpState.value == TcpState.CLOSED) {
+            logger.debug("Tcp session is closed, removing from session table, {}", this)
+            // todo: we need this to be per-session at some point
+            // outgoingQueue.put(SentinelPacket)
+        }
+    }
+
     init {
         protector.protectTCPSocket(channel.socket())
         tcpStateMachine.passiveOpen()
-        // this should throw an exception upon timeout to connect which we should catch in the kanon proxy and
-        // handle by sending an Icmp unreachable packet back.
-        logger.debug("TCP connecting to {}:{}", destinationAddress, destinationPort)
-        channel.socket().connect(InetSocketAddress(destinationAddress, destinationPort.toInt()), 1000)
-        logger.debug("TCP Connected")
-        CoroutineScope(Dispatchers.IO).launch {
+        outgoingScope.launch {
+            try {
+                logger.debug("TCP connecting to {}:{}", initialIpHeader.destinationAddress, initialTransportHeader.destinationPort)
+                channel.socket().connect(
+                    InetSocketAddress(initialIpHeader.destinationAddress, initialTransportHeader.destinationPort.toInt()),
+                    1000,
+                )
+                logger.debug("TCP Connected")
+                startIncomingHandling()
+            } catch (e: Exception) {
+                // this should catch any exceptions trying to make the TCP connection (timeout, not reachable etc.)
+                logger.error("Error creating the TCP session: ${e.message}")
+                val code =
+                    when (initialIpHeader.sourceAddress) {
+                        is Inet4Address -> IcmpV4DestinationUnreachableCodes.HOST_UNREACHABLE
+                        else -> IcmpV6DestinationUnreachableCodes.ADDRESS_UNREACHABLE
+                    }
+                val mtu =
+                    if (initialIpHeader.sourceAddress is Inet4Address) {
+                        TcpOptionMaximumSegmentSize.defaultIpv4MSS
+                    } else {
+                        TcpOptionMaximumSegmentSize.defaultIpv6MSS
+                    }
+                val response =
+                    IcmpFactory.createDestinationUnreachable(
+                        code,
+                        // source address for the Icmp header, send it back to the client as if its the clients own OS
+                        // telling it that its unreachable
+                        initialIpHeader.sourceAddress,
+                        initialIpHeader,
+                        initialTransportHeader,
+                        initialPayload,
+                        mtu.toInt(),
+                    )
+                returnQueue.add(response)
+                incomingQueue.clear() // prevent us from handling any incoming packets because we can't send them anywhere
+                close()
+            }
+
             try {
                 while (channel.isOpen) {
                     do {
@@ -65,17 +116,11 @@ class AnonymousTcpSession(
         }
     }
 
-    private fun close() {
-        if (channel.isOpen) {
-            try {
-                channel.close()
-            } catch (e: Exception) {
-                logger.error("Failed to close channel", e)
-            }
-        }
-        val finPacket = super.close(true)
+    override fun close() {
+        val finPacket = teardown(true)
         if (finPacket != null) {
             returnQueue.add(finPacket)
         }
+        super.close() // stop the incoming and outgoing jobs
     }
 }

--- a/src/main/kotlin/com/jasonernst/kanonproxy/tcp/TcpStateMachine.kt
+++ b/src/main/kotlin/com/jasonernst/kanonproxy/tcp/TcpStateMachine.kt
@@ -740,7 +740,7 @@ class TcpStateMachine(
                                         session.channel.write(buffer)
                                     }
                                 } catch (e: Exception) {
-                                    val packet = session.close()
+                                    val packet = session.teardown()
                                     if (packet != null) {
                                         return@runBlocking listOf(packet)
                                     } else {
@@ -780,7 +780,7 @@ class TcpStateMachine(
                                         ackNumber = transmissionControlBlock!!.rcv_nxt,
                                         transmissionControlBlock = transmissionControlBlock,
                                     )
-                                val finPacket = session.close()
+                                val finPacket = session.teardown()
                                 if (finPacket != null) {
                                     return@runBlocking listOf(ackPacket, finPacket)
                                 } else {
@@ -990,7 +990,7 @@ class TcpStateMachine(
                                 session.channel.write(buffer)
                             }
                         } catch (e: Exception) {
-                            val packet = session.close()
+                            val packet = session.teardown()
                             if (packet != null) {
                                 return@runBlocking listOf(packet)
                             } else {
@@ -1034,7 +1034,7 @@ class TcpStateMachine(
                                 ackNumber = transmissionControlBlock!!.rcv_nxt,
                                 transmissionControlBlock = transmissionControlBlock,
                             )
-                        val finPacket = session.close()
+                        val finPacket = session.teardown()
                         if (finPacket != null) {
                             return@runBlocking listOf(ackPacket, finPacket)
                         } else {
@@ -1237,7 +1237,7 @@ class TcpStateMachine(
                                 session.channel.write(buffer)
                             }
                         } catch (e: Exception) {
-                            val packet = session.close()
+                            val packet = session.teardown()
                             if (packet != null) {
                                 return@runBlocking listOf(packet)
                             } else {
@@ -1478,7 +1478,7 @@ class TcpStateMachine(
                             session.channel.write(buffer)
                         }
                     } catch (e: Exception) {
-                        val packet = session.close()
+                        val packet = session.teardown()
                         if (packet != null) {
                             return@runBlocking listOf(packet)
                         } else {
@@ -2612,10 +2612,10 @@ class TcpStateMachine(
     fun encapsulateOutgoingData(swapSourceDestination: Boolean = false): List<Packet> {
         return runBlocking {
             val packets = ArrayList<Packet>()
-            val sourceAddress = if (swapSourceDestination) session.destinationAddress else session.sourceAddress
-            val destinationAddress = if (swapSourceDestination) session.sourceAddress else session.destinationAddress
-            val sourcePort = if (swapSourceDestination) session.destinationPort else session.sourcePort
-            val destinationPort = if (swapSourceDestination) session.sourcePort else session.destinationPort
+            val sourceAddress = if (swapSourceDestination) session.getDestinationAddress() else session.getSourceAddress()
+            val destinationAddress = if (swapSourceDestination) session.getSourceAddress() else session.getDestinationAddress()
+            val sourcePort = if (swapSourceDestination) session.getDestinationPort() else session.getSourcePort()
+            val destinationPort = if (swapSourceDestination) session.getSourcePort() else session.getDestinationPort()
 
             val tcpHeader = TcpHeader(sourcePort = sourcePort, destinationPort = destinationPort)
             val ipHeader =

--- a/src/main/kotlin/com/jasonernst/kanonproxy/udp/UdpSession.kt
+++ b/src/main/kotlin/com/jasonernst/kanonproxy/udp/UdpSession.kt
@@ -1,72 +1,112 @@
 package com.jasonernst.kanonproxy.udp
 
+import com.jasonernst.icmp.common.v4.IcmpV4DestinationUnreachableCodes
+import com.jasonernst.icmp.common.v6.IcmpV6DestinationUnreachableCodes
 import com.jasonernst.kanonproxy.Session
+import com.jasonernst.kanonproxy.SessionManager
 import com.jasonernst.kanonproxy.VpnProtector
+import com.jasonernst.kanonproxy.icmp.IcmpFactory
 import com.jasonernst.knet.Packet
+import com.jasonernst.knet.network.ip.IpHeader
 import com.jasonernst.knet.network.ip.IpType
 import com.jasonernst.knet.network.ip.v4.Ipv4Header
 import com.jasonernst.knet.network.ip.v6.Ipv6Header
+import com.jasonernst.knet.transport.TransportHeader
+import com.jasonernst.knet.transport.tcp.options.TcpOptionMaximumSegmentSize
 import com.jasonernst.knet.transport.udp.UdpHeader
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
 import java.net.Inet4Address
 import java.net.Inet6Address
-import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.StandardProtocolFamily
+import java.nio.ByteBuffer
 import java.nio.channels.DatagramChannel
 import java.util.concurrent.LinkedBlockingDeque
 
 class UdpSession(
-    sourceAddress: InetAddress,
-    sourcePort: UShort,
-    destinationAddress: InetAddress,
-    destinationPort: UShort,
+    initialIpHeader: IpHeader,
+    initialTransportHeader: TransportHeader,
+    initialPayload: ByteArray,
     returnQueue: LinkedBlockingDeque<Packet>,
     protector: VpnProtector,
+    sessionManager: SessionManager,
 ) : Session(
-        sourceAddress = sourceAddress,
-        sourcePort = sourcePort,
-        destinationAddress = destinationAddress,
-        destinationPort = destinationPort,
-        protocol = IpType.UDP.value,
+        initialIpHeader = initialIpHeader,
+        initialTransportHeader = initialTransportHeader,
+        initialPayload = initialPayload,
         returnQueue = returnQueue,
         protector = protector,
+        sessionManager = sessionManager,
     ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
     override val channel: DatagramChannel =
-        if (destinationAddress is Inet4Address) {
+        if (initialIpHeader.destinationAddress is Inet4Address) {
             DatagramChannel.open(StandardProtocolFamily.INET)
         } else {
             DatagramChannel.open(StandardProtocolFamily.INET6)
         }
 
     init {
-        logger.debug("UDP connecting to {}:{}", destinationAddress, destinationPort)
-        protector.protectUDPSocket(channel.socket())
-        channel.connect(InetSocketAddress(destinationAddress, destinationPort.toInt()))
-        logger.debug("UDP Connected")
-        CoroutineScope(Dispatchers.IO).launch {
+        outgoingScope.launch {
             try {
+                logger.debug("UDP connecting to {}:{}", initialIpHeader.destinationAddress, initialTransportHeader.destinationPort)
+                protector.protectUDPSocket(channel.socket())
+                channel.connect(InetSocketAddress(initialIpHeader.destinationAddress, initialTransportHeader.destinationPort.toInt()))
+                logger.debug("UDP Connected")
+                startIncomingHandling()
+            } catch (e: Exception) {
+                logger.error("Error creating UDP session: ${e.message}")
+                val code =
+                    when (initialIpHeader.sourceAddress) {
+                        is Inet4Address -> IcmpV4DestinationUnreachableCodes.HOST_UNREACHABLE
+                        else -> IcmpV6DestinationUnreachableCodes.ADDRESS_UNREACHABLE
+                    }
+                val mtu =
+                    if (initialIpHeader.sourceAddress is Inet4Address) {
+                        TcpOptionMaximumSegmentSize.defaultIpv4MSS
+                    } else {
+                        TcpOptionMaximumSegmentSize.defaultIpv6MSS
+                    }
+                val response =
+                    IcmpFactory.createDestinationUnreachable(
+                        code,
+                        // source address for the Icmp header, send it back to the client as if its the clients own OS
+                        // telling it that its unreachable
+                        initialIpHeader.sourceAddress,
+                        initialIpHeader,
+                        initialTransportHeader,
+                        initialPayload,
+                        mtu.toInt(),
+                    )
+                returnQueue.add(response)
+            }
+
+            try {
+                logger.debug("UDP session listening for remote responses")
                 do {
                     val len = handleReturnTrafficLoop()
                 } while (channel.isOpen && len > -1)
             } catch (e: Exception) {
                 logger.warn("Remote Udp channel closed")
             }
+            logger.debug("UDP session no longer listening for remote responses")
         }
     }
 
     override fun handlePayloadFromInternet(payload: ByteArray) {
-        val udpHeader = UdpHeader(destinationPort, sourcePort, payload.size.toUShort(), 0u)
+        if (initialIpHeader == null || initialTransportHeader == null) {
+            logger.error("Initial headers are null, can't send return UDP traffic")
+            return
+        }
+        val udpHeader =
+            UdpHeader(initialTransportHeader!!.destinationPort, initialTransportHeader!!.sourcePort, payload.size.toUShort(), 0u)
         val ipHeader =
-            if (sourceAddress is Inet4Address) {
+            if (initialIpHeader!!.sourceAddress is Inet4Address) {
                 Ipv4Header(
-                    sourceAddress = destinationAddress as Inet4Address,
-                    destinationAddress = sourceAddress,
+                    sourceAddress = initialIpHeader!!.destinationAddress as Inet4Address,
+                    destinationAddress = initialIpHeader!!.sourceAddress as Inet4Address,
                     protocol = IpType.UDP.value,
                     totalLength =
                         (
@@ -77,13 +117,24 @@ class UdpSession(
                 )
             } else {
                 Ipv6Header(
-                    sourceAddress = destinationAddress as Inet6Address,
-                    destinationAddress = sourceAddress as Inet6Address,
+                    sourceAddress = initialIpHeader!!.destinationAddress as Inet6Address,
+                    destinationAddress = initialIpHeader!!.sourceAddress as Inet6Address,
                     protocol = IpType.UDP.value,
                     payloadLength = (40u + udpHeader.totalLength).toUShort(),
                 )
             }
         val packet = Packet(ipHeader, udpHeader, payload)
         returnQueue.put(packet)
+    }
+
+    override fun handlePacketFromClient(packet: Packet) {
+        val payload = packet.payload
+        try {
+            val bytesWrote = channel.write(ByteBuffer.wrap(payload))
+            logger.debug("Wrote {} bytes to session {}", bytesWrote, this)
+        } catch (e: Exception) {
+            logger.error("Error writing to UDP channel: $e")
+            close()
+        }
     }
 }

--- a/src/test/kotlin/com/jasonernst/kanonproxy/KAnonProxyTest.kt
+++ b/src/test/kotlin/com/jasonernst/kanonproxy/KAnonProxyTest.kt
@@ -1,0 +1,87 @@
+package com.jasonernst.kanonproxy
+
+import com.jasonernst.icmp.linux.IcmpLinux
+import com.jasonernst.kanonproxy.KAnonProxy.Companion.STALE_SESSION_MS
+import com.jasonernst.knet.Packet
+import com.jasonernst.knet.network.ip.IpType
+import com.jasonernst.knet.network.ip.v4.Ipv4Header
+import com.jasonernst.knet.transport.udp.UdpHeader
+import com.jasonernst.testservers.server.UdpEchoServer
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.slf4j.LoggerFactory
+import java.net.Inet4Address
+import java.net.InetAddress
+
+@Timeout(10)
+class KAnonProxyTest {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        val udpEchoServer: UdpEchoServer = UdpEchoServer()
+
+        @JvmStatic
+        @BeforeAll
+        fun setup() {
+            udpEchoServer.start()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun teardown() {
+            udpEchoServer.stop()
+        }
+    }
+
+    @Test fun startStop() {
+        val kAnonProxy = KAnonProxy(IcmpLinux)
+        kAnonProxy.start()
+        kAnonProxy.stop()
+    }
+
+    @Test fun udpSessionTimeout() {
+        val kAnonProxy = KAnonProxy(IcmpLinux)
+        kAnonProxy.start()
+
+        val payload = "Test Data".toByteArray()
+        val sourceAddress = InetAddress.getByName("127.0.0.1") as Inet4Address
+        val sourcePort: UShort = 12345u
+        val destinationAddress = InetAddress.getByName("127.0.0.1") as Inet4Address
+        val destinationPort: UShort = UdpEchoServer.UDP_DEFAULT_PORT.toUShort()
+        val udpHeader = UdpHeader(sourcePort, destinationPort, payload.size.toUShort(), 0u)
+        val packet =
+            Packet(
+                Ipv4Header(
+                    sourceAddress = sourceAddress,
+                    destinationAddress = destinationAddress,
+                    protocol = IpType.UDP.value,
+                    totalLength =
+                        (
+                            Ipv4Header.IP4_MIN_HEADER_LENGTH +
+                                udpHeader.totalLength +
+                                payload.size.toUShort()
+                        ).toUShort(),
+                ),
+                udpHeader,
+                payload,
+            )
+        kAnonProxy.handlePackets(listOf(packet))
+        val response = kAnonProxy.takeResponse()
+        logger.debug("Got response: {}", response.nextHeaders)
+        val parsedPayload = response.payload
+        Assertions.assertArrayEquals(payload, parsedPayload)
+
+        runBlocking {
+            delay(STALE_SESSION_MS + 1000)
+        }
+        assertTrue(kAnonProxy.sessionTableBySessionKey.isEmpty())
+
+        kAnonProxy.stop()
+    }
+}

--- a/src/test/kotlin/com/jasonernst/kanonproxy/QueueBlockingTest.kt
+++ b/src/test/kotlin/com/jasonernst/kanonproxy/QueueBlockingTest.kt
@@ -1,0 +1,100 @@
+package com.jasonernst.kanonproxy
+
+import com.jasonernst.icmp.linux.IcmpLinux
+import com.jasonernst.knet.Packet
+import com.jasonernst.knet.network.ip.IpType
+import com.jasonernst.knet.network.ip.v4.Ipv4Header
+import com.jasonernst.knet.network.ip.v4.Ipv4Header.Companion.IP4_MIN_HEADER_LENGTH
+import com.jasonernst.knet.transport.tcp.TcpHeader
+import com.jasonernst.knet.transport.udp.UdpHeader
+import com.jasonernst.testservers.server.UdpEchoServer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.slf4j.LoggerFactory
+import java.net.Inet4Address
+import java.net.InetAddress
+
+@Timeout(6)
+class QueueBlockingTest {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val kAnonProxy = KAnonProxy(IcmpLinux)
+
+    companion object {
+        val udpEchoServer: UdpEchoServer = UdpEchoServer()
+
+        @JvmStatic
+        @BeforeAll
+        fun setup() {
+            udpEchoServer.start()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun teardown() {
+            udpEchoServer.stop()
+        }
+    }
+
+    @Test @BeforeEach
+    fun beforeEach() {
+        kAnonProxy.start()
+    }
+
+    @Test @AfterEach
+    fun afterEach() {
+        kAnonProxy.stop()
+    }
+
+    // if this test fails, the TCP connection handling is blocking the queue and the UDP packet can't get through
+    // if it succeeds, the TCP connection handling happens simultaneously with the UDP packet handling
+    @Test
+    fun slowConnectionDoesntBlockQueue() {
+        val tcpSyn = TcpHeader(syn = true)
+        val tcpIpHeader =
+            Ipv4Header(
+                destinationAddress = InetAddress.getByName("8.8.8.8") as Inet4Address,
+                protocol = IpType.TCP.value,
+                totalLength =
+                    (
+                        IP4_MIN_HEADER_LENGTH +
+                            tcpSyn.getHeaderLength()
+                    ).toUShort(),
+            )
+        val tcpPacket = Packet(tcpIpHeader, tcpSyn, ByteArray(0))
+
+        val udpPayload = "Test Data".toByteArray()
+        val udpHeader = UdpHeader(12345u, UdpEchoServer.UDP_DEFAULT_PORT.toUShort(), udpPayload.size.toUShort(), 0u)
+        val udpIpHeader =
+            Ipv4Header(
+                destinationAddress = InetAddress.getByName("127.0.0.1") as Inet4Address,
+                protocol = IpType.UDP.value,
+                totalLength =
+                    (
+                        IP4_MIN_HEADER_LENGTH +
+                            udpHeader.totalLength +
+                            udpPayload.size.toUShort()
+                    ).toUShort(),
+            )
+        val udpPacket = Packet(udpIpHeader, udpHeader, udpPayload)
+
+        kAnonProxy.handlePackets(listOf(tcpPacket, udpPacket))
+
+        // we expect the UDP echo server to return the echo before we get the destination unreachable message about the
+        // TCP syn
+        val recvPacket = kAnonProxy.takeResponse()
+        logger.info("Received packet: $recvPacket")
+        assertTrue(recvPacket.ipHeader != null)
+
+        assertTrue(recvPacket.ipHeader!!.protocol == IpType.UDP.value)
+        val recvPacket2 = kAnonProxy.takeResponse()
+        logger.info("Received packet: $recvPacket2")
+        assertTrue(recvPacket2.ipHeader != null)
+        // should be a destination unreachable message
+        assertTrue(recvPacket2.ipHeader!!.protocol == IpType.ICMP.value)
+    }
+}

--- a/src/test/kotlin/com/jasonernst/kanonproxy/tcp/TcpClient.kt
+++ b/src/test/kotlin/com/jasonernst/kanonproxy/tcp/TcpClient.kt
@@ -97,7 +97,7 @@ class TcpClient(
         while (isRunning) {
             val packet = outgoingPackets.take()
             if (packet == SentinelPacket) {
-                logger.debug("Got sentinel packet, stopping")
+                logger.warn("Got sentinel packet, stopping writer")
                 break
             }
             logger.debug("Sending to proxy in state: {}: {}", tcpStateMachine.tcpState.value, packet)
@@ -113,14 +113,14 @@ class TcpClient(
         while (isRunning) {
             val packet = kAnonProxy.takeResponse()
             if (packet == SentinelPacket) {
-                logger.debug("Got sentinel packet, stopping")
+                logger.warn("Got sentinel packet, stopping reader")
                 break
             }
             if (packet.ipHeader == null || packet.nextHeaders == null || packet.payload == null) {
                 logger.debug("missing header(s) or payload, skipping packet")
                 continue
             }
-            logger.debug("Received from proxy in state: {}: {}", tcpStateMachine.tcpState.value, packet)
+            logger.debug("Received from proxy in state: {}: {}", tcpStateMachine.tcpState.value, packet.nextHeaders)
             packetDumper.dumpBuffer(
                 ByteBuffer.wrap(packet.toByteArray()),
                 etherType = com.jasonernst.packetdumper.ethernet.EtherType.DETECT,
@@ -308,6 +308,7 @@ class TcpClient(
      * In the Tcp Client, this is actually handling packets it got from the proxy
      */
     override fun handlePacketFromClient(packet: Packet) {
+        logger.error("GOT HERE")
     }
 
     override fun getSourcePort(): UShort = sourcePort


### PR DESCRIPTION
Updated session handling so that incoming packets for a session are handled by a incoming handler.

The effect of this is that the initial creation of a session no longer happens in the calling thread. The error handling for a bad tcp connect call is moved into the tcp session itself and shifted out of the kanon proxy. 

The effect is that a slow / unresponsive tcp connect call will no longer block other subsequent sessions like UDP sessions or other TCP sessions.