### PR TITLE
Non-blocking IO

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
         run: ./gradlew clean assemble --no-build-cache
       - name: JVM unit Tests with Coverage Report
         run: ./gradlew check
+        timeout-minutes: 3
       # tar the reports since its much faster uploading multiple files
       - name: Tar Reports
         if: always()

--- a/core/src/main/kotlin/com/jasonernst/kanonproxy/BidirectionalByteChannel.kt
+++ b/core/src/main/kotlin/com/jasonernst/kanonproxy/BidirectionalByteChannel.kt
@@ -47,4 +47,12 @@ class BidirectionalByteChannel : ByteChannel {
         buffer.compact()
         return availableBytes
     }
+
+    fun available(): Int {
+        return if (readyToRead.value.not()) {
+            0
+        } else {
+            buffer.position() // because we haven't flipped yet, this will be how many bytes there are to read
+        }
+    }
 }

--- a/core/src/main/kotlin/com/jasonernst/kanonproxy/BidirectionalByteChannel.kt
+++ b/core/src/main/kotlin/com/jasonernst/kanonproxy/BidirectionalByteChannel.kt
@@ -48,11 +48,10 @@ class BidirectionalByteChannel : ByteChannel {
         return availableBytes
     }
 
-    fun available(): Int {
-        return if (readyToRead.value.not()) {
+    fun available(): Int =
+        if (readyToRead.value.not()) {
             0
         } else {
             buffer.position() // because we haven't flipped yet, this will be how many bytes there are to read
         }
-    }
 }

--- a/core/src/main/kotlin/com/jasonernst/kanonproxy/BidirectionalByteChannel.kt
+++ b/core/src/main/kotlin/com/jasonernst/kanonproxy/BidirectionalByteChannel.kt
@@ -17,6 +17,7 @@ class BidirectionalByteChannel : ByteChannel {
 
     override fun close() {
         this.isOpen = false
+        readyToRead.value = true
     }
 
     override fun write(src: ByteBuffer): Int {
@@ -34,6 +35,9 @@ class BidirectionalByteChannel : ByteChannel {
             runBlocking {
                 readyToRead.takeWhile { !it }.collect {}
             }
+        }
+        if (!isOpen) {
+            return 0
         }
         // flip the buffer to get it from write mode to read mode
         buffer.flip()

--- a/core/src/main/kotlin/com/jasonernst/kanonproxy/ChangeRequest.kt
+++ b/core/src/main/kotlin/com/jasonernst/kanonproxy/ChangeRequest.kt
@@ -1,0 +1,15 @@
+package com.jasonernst.kanonproxy
+
+import java.nio.channels.spi.AbstractSelectableChannel
+
+// https://rox-xmlrpc.sourceforge.net/niotut/
+data class ChangeRequest(
+    val channel: AbstractSelectableChannel,
+    val type: Int,
+    val ops: Int,
+) {
+    companion object {
+        const val REGISTER = 1
+        const val CHANGE_OPS = 2
+    }
+}

--- a/core/src/main/kotlin/com/jasonernst/kanonproxy/Session.kt
+++ b/core/src/main/kotlin/com/jasonernst/kanonproxy/Session.kt
@@ -1,24 +1,35 @@
 package com.jasonernst.kanonproxy
 
+import com.jasonernst.icmp.common.v4.IcmpV4DestinationUnreachableCodes
+import com.jasonernst.icmp.common.v6.IcmpV6DestinationUnreachableCodes
 import com.jasonernst.kanonproxy.tcp.AnonymousTcpSession
 import com.jasonernst.kanonproxy.udp.UdpSession
 import com.jasonernst.knet.Packet
 import com.jasonernst.knet.SentinelPacket
+import com.jasonernst.knet.network.icmp.IcmpFactory
 import com.jasonernst.knet.network.ip.IpHeader
 import com.jasonernst.knet.network.ip.IpType
 import com.jasonernst.knet.transport.TransportHeader
+import com.jasonernst.knet.transport.tcp.options.TcpOptionMaximumSegmentSize
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
+import java.net.Inet4Address
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.channels.ByteChannel
 import java.nio.channels.CancelledKeyException
+import java.nio.channels.ClosedSelectorException
+import java.nio.channels.SelectionKey
 import java.nio.channels.Selector
+import java.nio.channels.SocketChannel
+import java.nio.channels.spi.AbstractSelectableChannel
+import java.util.LinkedList
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.min
@@ -33,7 +44,6 @@ abstract class Session(
     val clientAddress: InetSocketAddress,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
-    val selector = Selector.open()
     abstract val channel: ByteChannel
     val outgoingToInternet = BidirectionalByteChannel()
     protected val readBuffer = ByteBuffer.allocate(DEFAULT_BUFFER_SIZE)
@@ -44,10 +54,13 @@ abstract class Session(
     val incomingQueue = LinkedBlockingDeque<Packet>()
     private val incomingJob = SupervisorJob()
     private val incomingScope = CoroutineScope(Dispatchers.IO + incomingJob)
-    private val isRunning = AtomicBoolean(false)
+    private val isRunning = AtomicBoolean(true)
 
     private val channelJob = SupervisorJob()
     private val channelScope = CoroutineScope(Dispatchers.IO + channelJob)
+
+    val selector: Selector = Selector.open()
+    val changeRequests = LinkedList<ChangeRequest>()
 
     companion object {
         fun getKey(
@@ -99,10 +112,107 @@ abstract class Session(
             }
     }
 
-    fun getKey(): String = getKey(getSourceAddress(), getSourcePort(), getDestinationAddress(), getDestinationPort(), getProtocol())
+    open fun getKey(): String = getKey(getSourceAddress(), getSourcePort(), getDestinationAddress(), getDestinationPort(), getProtocol())
 
     override fun toString(): String =
         "Session(clientAddress='$clientAddress' sourceAddress='${getSourceAddress()}', sourcePort=${getSourcePort()}, destinationAddress='${getDestinationAddress()}', destinationPort=${getDestinationPort()}, protocol=${getProtocol()})"
+
+    fun readyToWrite() {
+        if (channel is BidirectionalByteChannel) {
+            return
+        }
+        synchronized(changeRequests) {
+            changeRequests.add(ChangeRequest(channel as AbstractSelectableChannel, ChangeRequest.REGISTER, SelectionKey.OP_WRITE))
+        }
+        selector.wakeup()
+    }
+
+    fun startSelector() {
+        channelScope.launch {
+            Thread.currentThread().name = "Channel scope: ${getKey()}"
+            while (isRunning.get()) {
+                try {
+                    // Process any pending changes
+                    synchronized(changeRequests) {
+                        for (changeRequest in changeRequests) {
+                            when (changeRequest.type) {
+                                ChangeRequest.REGISTER -> {
+                                    logger.debug("Processing REGISTER")
+                                    changeRequest.channel.register(selector, changeRequest.ops)
+                                }
+                                ChangeRequest.CHANGE_OPS -> {
+                                    logger.debug("Processing CHANGE_OPS")
+                                    val key = changeRequest.channel.keyFor(selector)
+                                    key.interestOps(changeRequest.ops)
+                                }
+                            }
+                        }
+                        changeRequests.clear()
+                    }
+                    logger.warn("Waiting for SELECT")
+                    // lock so we don't add or remove from the selector while we're selecting
+                    val numKeys = selector.select()
+                    if (numKeys > 0) {
+                        logger.warn("SELECT RETURNED: $numKeys")
+                    }
+                } catch (e: Exception) {
+                    logger.warn("Exception on select, probably shutting down: $e")
+                    break
+                }
+
+                try {
+                    val selectedKeys = selector.selectedKeys()
+                    if (selectedKeys.size > 0) {
+                        logger.warn("SELECT: $selectedKeys")
+                    }
+                    val keyStream = selectedKeys.parallelStream()
+                    keyStream
+                        .filter { it.isWritable || it.isReadable || it.isConnectable }
+                        .forEach {
+                            if (it.isWritable && it.isValid) {
+                                val available = outgoingToInternet.available()
+                                if (available > 0) {
+                                    val buff = ByteBuffer.allocate(available)
+                                    outgoingToInternet.read(buff)
+                                    buff.flip()
+                                    flushToRealChannel(buff)
+                                }
+                                it.interestOps(SelectionKey.OP_READ)
+                            }
+                            if (it.isReadable && it.isValid) {
+                                read()
+                            }
+                            if (it.isConnectable) {
+                                val socketChannel = it.channel() as SocketChannel
+                                logger.debug("Tcp connectable, trying to finish connection to ${socketChannel.remoteAddress}")
+                                if (socketChannel.isConnectionPending) {
+                                    try {
+                                        val result = socketChannel.finishConnect()
+                                        if (result) {
+                                            logger.debug("Tcp connection successful")
+                                            it.interestOps(SelectionKey.OP_READ)
+                                            startIncomingHandling()
+                                        } else {
+                                            logger.debug("Finishing connection, still in progress")
+                                            // will retry again when the selector wakes up
+                                        }
+                                    } catch (e: Exception) {
+                                        handleExceptionOnRemoteChannel(e)
+                                    }
+                                }
+                            }
+                        }
+                    selectedKeys.clear()
+                } catch (e: CancelledKeyException) {
+                    logger.warn("Canceled key, probably shutting session down")
+                    break
+                } catch (e: ClosedSelectorException) {
+                    logger.warn("Selector closed, probably shutting session down")
+                    break
+                }
+            }
+        }
+    }
 
     open fun handleReturnTrafficLoop(maxRead: Int): Int {
         val realLimit = min(maxRead, readBuffer.capacity())
@@ -122,17 +232,46 @@ abstract class Session(
 
     abstract fun read()
 
+    fun handleExceptionOnRemoteChannel(e: Exception) {
+        logger.error("Error creating session $this : ${e.message}")
+        val sourceIpHeader = initialIpHeader
+        if (sourceIpHeader == null) {
+            logger.error("Initial IP header is null, can't create ICMP packet")
+            return
+        }
+        val code =
+            when (sourceIpHeader.sourceAddress) {
+                is Inet4Address -> IcmpV4DestinationUnreachableCodes.HOST_UNREACHABLE
+                else -> IcmpV6DestinationUnreachableCodes.ADDRESS_UNREACHABLE
+            }
+        val mtu =
+            if (sourceIpHeader.sourceAddress is Inet4Address) {
+                TcpOptionMaximumSegmentSize.defaultIpv4MSS
+            } else {
+                TcpOptionMaximumSegmentSize.defaultIpv6MSS
+            }
+        val response =
+            IcmpFactory.createDestinationUnreachable(
+                code,
+                // source address for the Icmp header, send it back to the client as if its the clients own OS
+                // telling it that its unreachable
+                sourceIpHeader.sourceAddress,
+                Packet(
+                    initialIpHeader,
+                    initialTransportHeader,
+                    initialPayload,
+                ),
+                mtu.toInt(),
+            )
+        returnQueue.add(response)
+    }
+
     /**
      * Should be called after the connection to the remote side is established. This will start the loop that reads
      * from the incoming queue and handles each packet. Until this point, packets will just build up here. This is to
      * prevent us from responding with an ACK before the connection is established.
      */
     fun startIncomingHandling() {
-        if (isRunning.get()) {
-            logger.warn("Incoming handling already started")
-            return
-        }
-        isRunning.set(true)
         incomingScope.launch {
             Thread.currentThread().name = "Incoming handler: ${getKey()}"
             while (isRunning.get()) {
@@ -143,42 +282,6 @@ abstract class Session(
                     break
                 }
                 handlePacketFromClient(packet)
-            }
-        }
-
-        channelScope.launch {
-            Thread.currentThread().name = "Channel scope: ${getKey()}"
-            while (isRunning.get()) {
-                try {
-                    selector.select()
-                } catch (e: Exception) {
-                    logger.warn("Exception on select, probably shutting down: $e")
-                    break
-                }
-                val selectedKeys = selector.selectedKeys()
-                val keyStream = selectedKeys.parallelStream()
-                try {
-                    keyStream
-                        .filter { (it.isWritable || it.isReadable) && it.isValid }
-                        .forEach {
-                            if (it.isWritable) {
-                                val available = outgoingToInternet.available()
-                                if (available > 0) {
-                                    val buff = ByteBuffer.allocate(available)
-                                    outgoingToInternet.read(buff)
-                                    buff.flip()
-                                    flushToRealChannel(buff)
-                                }
-                            }
-                            if (it.isReadable) {
-                                read()
-                            }
-                        }
-                } catch (e: CancelledKeyException) {
-                    logger.warn("Canceled key, probably shutting session down")
-                    break
-                }
-                selectedKeys.clear()
             }
         }
     }
@@ -210,6 +313,7 @@ abstract class Session(
     open fun close(
         removeSession: Boolean = true,
         packet: Packet? = null,
+        isIncomingJob: Boolean = false,
     ) {
         logger.debug("Closing session")
         if (channel.isOpen) {
@@ -218,6 +322,12 @@ abstract class Session(
             } catch (e: Exception) {
                 logger.error("Failed to close channel", e)
             }
+        }
+        if (selector.isOpen) {
+            selector.close()
+        }
+        if (outgoingToInternet.isOpen) {
+            outgoingToInternet.close()
         }
         isRunning.set(false)
         incomingQueue.add(SentinelPacket)
@@ -238,8 +348,19 @@ abstract class Session(
             sessionManager.handlePackets(listOf(packet), clientAddress)
         }
         runBlocking {
-            outgoingJob.cancel()
-            incomingJob.cancel()
+            logger.debug("Stopping outgoing job")
+            outgoingJob.cancelAndJoin()
+            logger.debug("Outgoing job stopped. Stopping incoming job")
+
+            if (isIncomingJob) {
+                logger.debug("Not cancelling incoming job because we're currently running in it")
+            } else {
+                incomingJob.cancelAndJoin()
+            }
+
+            logger.debug("Incoming job stopped. Stopping channel job")
+            channelJob.cancelAndJoin()
+            logger.debug("Channel job stopped")
         }
         logger.debug("Session closed")
     }

--- a/core/src/main/kotlin/com/jasonernst/kanonproxy/Session.kt
+++ b/core/src/main/kotlin/com/jasonernst/kanonproxy/Session.kt
@@ -1,7 +1,6 @@
 package com.jasonernst.kanonproxy
 
 import com.jasonernst.kanonproxy.tcp.AnonymousTcpSession
-import com.jasonernst.kanonproxy.tcp.TcpSession
 import com.jasonernst.kanonproxy.udp.UdpSession
 import com.jasonernst.knet.Packet
 import com.jasonernst.knet.SentinelPacket
@@ -19,11 +18,9 @@ import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.channels.ByteChannel
 import java.nio.channels.CancelledKeyException
-import java.nio.channels.DatagramChannel
 import java.nio.channels.Selector
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.min
 
 abstract class Session(
@@ -161,7 +158,8 @@ abstract class Session(
                 val selectedKeys = selector.selectedKeys()
                 val keyStream = selectedKeys.parallelStream()
                 try {
-                    keyStream.filter { (it.isWritable || it.isReadable) && it.isValid }
+                    keyStream
+                        .filter { (it.isWritable || it.isReadable) && it.isValid }
                         .forEach {
                             if (it.isWritable) {
                                 val available = outgoingToInternet.available()

--- a/core/src/main/kotlin/com/jasonernst/kanonproxy/tcp/AnonymousTcpSession.kt
+++ b/core/src/main/kotlin/com/jasonernst/kanonproxy/tcp/AnonymousTcpSession.kt
@@ -83,7 +83,7 @@ class AnonymousTcpSession(
                 channel.socket().keepAlive = false
                 channel.configureBlocking(false)
                 channel.register(selector, SelectionKey.OP_READ or SelectionKey.OP_WRITE)
-                channel.socket().connect(InetSocketAddress(initialIpHeader.destinationAddress, initialTransportHeader.destinationPort.toInt()))
+                channel.connect(InetSocketAddress(initialIpHeader.destinationAddress, initialTransportHeader.destinationPort.toInt()))
                 logger.debug("TCP connected")
                 startIncomingHandling()
             } catch (e: Exception) {

--- a/core/src/main/kotlin/com/jasonernst/kanonproxy/tcp/AnonymousTcpSession.kt
+++ b/core/src/main/kotlin/com/jasonernst/kanonproxy/tcp/AnonymousTcpSession.kt
@@ -1,19 +1,15 @@
 package com.jasonernst.kanonproxy.tcp
 
-import com.jasonernst.icmp.common.v4.IcmpV4DestinationUnreachableCodes
-import com.jasonernst.icmp.common.v6.IcmpV6DestinationUnreachableCodes
+import com.jasonernst.kanonproxy.ChangeRequest
 import com.jasonernst.kanonproxy.SessionManager
 import com.jasonernst.kanonproxy.VpnProtector
 import com.jasonernst.knet.Packet
-import com.jasonernst.knet.network.icmp.IcmpFactory
 import com.jasonernst.knet.network.ip.IpHeader
 import com.jasonernst.knet.transport.TransportHeader
 import com.jasonernst.knet.transport.tcp.TcpHeader
-import com.jasonernst.knet.transport.tcp.options.TcpOptionMaximumSegmentSize
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
-import java.net.Inet4Address
 import java.net.InetSocketAddress
 import java.nio.channels.SelectionKey
 import java.nio.channels.SocketChannel
@@ -69,49 +65,42 @@ class AnonymousTcpSession(
 
         if (tcpStateMachine.tcpState.value == TcpState.CLOSED) {
             logger.debug("Tcp session is closed, removing from session table, {}", this)
-            super.close(removeSession = true, packet = null)
+            super.close(removeSession = true, packet = null, true)
         }
     }
 
     init {
+        startSelector()
         protector.protectTCPSocket(channel.socket())
         tcpStateMachine.passiveOpen()
         outgoingScope.launch {
             Thread.currentThread().name = "Outgoing handler: ${getKey()}"
             try {
                 logger.debug("TCP connecting to {}:{}", initialIpHeader.destinationAddress, initialTransportHeader.destinationPort)
-                channel.socket().keepAlive = false
+                channel.socket().keepAlive = true
+                channel.socket().keepAlive = true
+                channel.socket().soTimeout = 0
                 channel.configureBlocking(false)
-                channel.register(selector, SelectionKey.OP_READ or SelectionKey.OP_WRITE)
-                channel.connect(InetSocketAddress(initialIpHeader.destinationAddress, initialTransportHeader.destinationPort.toInt()))
-                logger.debug("TCP connected")
-                startIncomingHandling()
-            } catch (e: Exception) {
-                // this should catch any exceptions trying to make the TCP connection (timeout, not reachable etc.)
-                logger.error("Error creating the TCP session: $e")
-                val code =
-                    when (initialIpHeader.sourceAddress) {
-                        is Inet4Address -> IcmpV4DestinationUnreachableCodes.HOST_UNREACHABLE
-                        else -> IcmpV6DestinationUnreachableCodes.ADDRESS_UNREACHABLE
-                    }
-                val mtu =
-                    if (initialIpHeader.sourceAddress is Inet4Address) {
-                        TcpOptionMaximumSegmentSize.defaultIpv4MSS
-                    } else {
-                        TcpOptionMaximumSegmentSize.defaultIpv6MSS
-                    }
-                val response =
-                    IcmpFactory.createDestinationUnreachable(
-                        code,
-                        // source address for the Icmp header, send it back to the client as if its the clients own OS
-                        // telling it that its unreachable
-                        initialIpHeader.sourceAddress,
-                        Packet(initialIpHeader, initialTransportHeader, initialPayload),
-                        mtu.toInt(),
+                val result =
+                    channel.connect(
+                        InetSocketAddress(initialIpHeader.destinationAddress, initialTransportHeader.destinationPort.toInt()),
                     )
-                returnQueue.add(response)
-                // incomingQueue.clear() // prevent us from handling any incoming packets because we can't send them anywhere
-                close()
+                if (result) {
+                    // this can either be connected immediately, or we'll have to wait for the selector
+                    logger.debug("TCP connected to ${initialIpHeader.destinationAddress}")
+                    synchronized(changeRequests) {
+                        changeRequests.add(ChangeRequest(channel, ChangeRequest.REGISTER, SelectionKey.OP_READ))
+                    }
+                    startIncomingHandling()
+                } else {
+                    logger.debug("CONNECT called, waiting for selector")
+                    synchronized(changeRequests) {
+                        changeRequests.add(ChangeRequest(channel, ChangeRequest.REGISTER, SelectionKey.OP_CONNECT))
+                    }
+                }
+                selector.wakeup()
+            } catch (e: Exception) {
+                handleExceptionOnRemoteChannel(e)
             }
         }
     }

--- a/core/src/main/kotlin/com/jasonernst/kanonproxy/tcp/TcpStateMachine.kt
+++ b/core/src/main/kotlin/com/jasonernst/kanonproxy/tcp/TcpStateMachine.kt
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory
 import java.net.Inet4Address
 import java.net.Inet6Address
 import java.nio.ByteBuffer
+import java.util.ArrayList
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.jvm.javaClass
 import kotlin.math.abs
@@ -161,7 +162,7 @@ class TcpStateMachine(
         tcpHeader: TcpHeader,
         payload: ByteArray,
     ): List<Packet> {
-        logger.warn("Packet handling, acquiring lock")
+        // logger.warn("Packet handling, acquiring lock")
         val packets =
             runBlocking {
                 tcbMutex.withLock {
@@ -229,7 +230,7 @@ class TcpStateMachine(
                     }
                 }
             }
-        logger.warn("Packet handling, releasing lock")
+        // logger.warn("Packet handling, releasing lock")
 
         // run this outside of the mutex since it also requires locking
         val encapsulatedPackets = encapsulateOutgoingData(swapSourceDestination, false)
@@ -1805,6 +1806,7 @@ class TcpStateMachine(
                     // can't write directly to the channel because we can deadlock with reads on it.
                     // session.channel.write(buffer)
                 }
+                session.readyToWrite()
             } catch (e: Exception) {
                 logger.warn("Error writing to channel: $e, shutting down session")
                 val finPacket = session.teardown(!swapSourceDestination, requiresLock = false)

--- a/core/src/main/kotlin/com/jasonernst/kanonproxy/tcp/TcpStateMachine.kt
+++ b/core/src/main/kotlin/com/jasonernst/kanonproxy/tcp/TcpStateMachine.kt
@@ -1801,7 +1801,9 @@ class TcpStateMachine(
             try {
                 val buffer = ByteBuffer.wrap(payload)
                 while (buffer.hasRemaining()) {
-                    session.channel.write(buffer)
+                    session.outgoingToInternet.write(buffer)
+                    // can't write directly to the channel because we can deadlock with reads on it.
+                    // session.channel.write(buffer)
                 }
             } catch (e: Exception) {
                 logger.warn("Error writing to channel: $e, shutting down session")

--- a/core/src/test/kotlin/com/jasonernst/kanonproxy/QueueBlockingTest.kt
+++ b/core/src/test/kotlin/com/jasonernst/kanonproxy/QueueBlockingTest.kt
@@ -1,6 +1,7 @@
 package com.jasonernst.kanonproxy
 
 import com.jasonernst.icmp.linux.IcmpLinux
+import com.jasonernst.kanonproxy.icmp.IcmpHandlingTest.Companion.UNREACHABLE_IPV4
 import com.jasonernst.knet.Packet
 import com.jasonernst.knet.network.ip.IpType
 import com.jasonernst.knet.network.ip.v4.Ipv4Header
@@ -59,7 +60,7 @@ class QueueBlockingTest {
         val tcpSyn = TcpHeader(syn = true)
         val tcpIpHeader =
             Ipv4Header(
-                destinationAddress = InetAddress.getByName("8.8.8.8") as Inet4Address,
+                destinationAddress = InetAddress.getByName(UNREACHABLE_IPV4) as Inet4Address,
                 protocol = IpType.TCP.value,
                 totalLength =
                     (

--- a/core/src/test/kotlin/com/jasonernst/kanonproxy/tcp/TcpClient.kt
+++ b/core/src/test/kotlin/com/jasonernst/kanonproxy/tcp/TcpClient.kt
@@ -338,6 +338,10 @@ class TcpClient(
     override fun toString(): String =
         "TcpClient(sourceAddress='$sourceAddress', destinationAddress='$destinationAddress', sourcePort=$sourcePort, destinationPort=$destinationPort, clientId=$clientId)"
 
+    override fun read() {
+        TODO("Not yet implemented")
+    }
+
     /**
      * In the Tcp Client, this is actually handling packets it got from the proxy
      */

--- a/core/src/test/kotlin/com/jasonernst/kanonproxy/tcp/TcpClient.kt
+++ b/core/src/test/kotlin/com/jasonernst/kanonproxy/tcp/TcpClient.kt
@@ -338,6 +338,8 @@ class TcpClient(
     override fun toString(): String =
         "TcpClient(sourceAddress='$sourceAddress', destinationAddress='$destinationAddress', sourcePort=$sourcePort, destinationPort=$destinationPort, clientId=$clientId)"
 
+    override fun getKey(): String = getKey(sourceAddress, sourcePort, destinationAddress, destinationPort, IpType.TCP.value)
+
     override fun read() {
         TODO("Not yet implemented")
     }

--- a/core/src/test/kotlin/com/jasonernst/kanonproxy/tcp/TcpClient.kt
+++ b/core/src/test/kotlin/com/jasonernst/kanonproxy/tcp/TcpClient.kt
@@ -154,7 +154,7 @@ class TcpClient(
     /**
      * Blocks until the three-way handshake completes, or fails
      */
-    fun connect(timeOutMs: Long = 2000) {
+    fun connect(timeOutMs: Long = KAnonProxy.STALE_SESSION_MS + 500L) {
         if (tcpStateMachine.tcpState.value != TcpState.CLOSED) {
             throw RuntimeException("Can't connect, current session isn't closed")
         }

--- a/core/src/test/kotlin/com/jasonernst/kanonproxy/tcp/TcpHandlingTest.kt
+++ b/core/src/test/kotlin/com/jasonernst/kanonproxy/tcp/TcpHandlingTest.kt
@@ -262,7 +262,7 @@ class TcpHandlingTest {
         val destinationPort: UShort = TcpEchoServer.TCP_DEFAULT_PORT.toUShort()
 
         val tcpClient = TcpClient(sourceAddress, destinationAddress, sourcePort, destinationPort, kAnonProxy, packetDumper)
-        assertThrows<SocketException> { tcpClient.connect(2000) }
+        assertThrows<SocketException> { tcpClient.connect() }
         tcpClient.stopClient()
     }
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 jacoco {


### PR DESCRIPTION
Previously we were reading and writing from the socket on two different threads at the same time which led to deadlock quite often.

This switches the IO to use a selector following this guide: https://rox-xmlrpc.sourceforge.net/niotut/ where the selector is only ever modified by a single thread. 

By default, we are always in read mode on the remote socket, and then when data is ready, we switch to read mode and write.

I also updated the jdk to java 21.