### PR TITLE
Only read from remote when buffer isn't full

### DIFF
--- a/core/src/main/kotlin/com/jasonernst/kanonproxy/tcp/AnonymousTcpSession.kt
+++ b/core/src/main/kotlin/com/jasonernst/kanonproxy/tcp/AnonymousTcpSession.kt
@@ -120,6 +120,7 @@ class AnonymousTcpSession(
                     handleReturnTrafficLoop(maxRead)
                 } else {
                     logger.warn("No more space in outgoing buffer, waiting for more space")
+                    changeRequests.add(ChangeRequest(channel, ChangeRequest.CHANGE_OPS, 0))
                     0
                 }
             if (len < 0) {


### PR DESCRIPTION
Previously we spun waiting for the writer thread to free up space.