### PR TITLE
Client channels instead of sockets, non-blocking IO

### DIFF
--- a/android/src/main/kotlin/com/jasonernst/kanonproxy/AndroidClient.kt
+++ b/android/src/main/kotlin/com/jasonernst/kanonproxy/AndroidClient.kt
@@ -6,15 +6,15 @@ import android.os.ParcelFileDescriptor.AutoCloseOutputStream
 import com.jasonernst.packetdumper.AbstractPacketDumper
 import com.jasonernst.packetdumper.DummyPacketDumper
 import java.net.InetAddress
-import java.net.InetSocketAddress
+import java.nio.channels.DatagramChannel
 
 class AndroidClient(
-    socketAddress: InetSocketAddress = InetSocketAddress("127.0.0.1", 8080),
+    datagramChannel: DatagramChannel,
     packetDumper: AbstractPacketDumper = DummyPacketDumper,
     vpnFileDescriptor: ParcelFileDescriptor,
     onlyDestinations: List<InetAddress> = emptyList(),
     onlyProtocols: List<UByte> = emptyList()
-) : Client(socketAddress, packetDumper, onlyDestinations, onlyProtocols) {
+) : Client(datagramChannel, packetDumper, onlyDestinations, onlyProtocols) {
 
     private val inputStream = AutoCloseInputStream(vpnFileDescriptor)
     private val outputStream = AutoCloseOutputStream(vpnFileDescriptor)
@@ -27,5 +27,4 @@ class AndroidClient(
         outputStream.write(writeBytes)
         outputStream.flush()
     }
-
 }

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -34,6 +34,7 @@ jacoco {
 }
 
 dependencies {
+    implementation(project(":core")) // only really for the DEFAULT_PORT
     implementation(libs.jna)
     implementation(libs.jnr.enxio)
     implementation(libs.knet)

--- a/client/src/main/kotlin/com/jasonernst/kanonproxy/tuntap/TunTapDevice.kt
+++ b/client/src/main/kotlin/com/jasonernst/kanonproxy/tuntap/TunTapDevice.kt
@@ -1,12 +1,34 @@
 package com.jasonernst.kanonproxy.tuntap
 
+import com.jasonernst.kanonproxy.ChangeRequest
+import com.jasonernst.kanonproxy.ChangeRequest.Companion.CHANGE_OPS
+import com.jasonernst.kanonproxy.ChangeRequest.Companion.REGISTER
 import com.sun.jna.Native
 import com.sun.jna.NativeLong
+import jnr.enxio.channels.NativeSelectorProvider
 import jnr.enxio.channels.NativeSocketChannel
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
+import java.nio.channels.SelectionKey.OP_READ
+import java.nio.channels.SelectionKey.OP_WRITE
+import java.nio.channels.Selector
+import java.util.LinkedList
+import java.util.concurrent.LinkedBlockingDeque
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.experimental.or
+import kotlin.math.min
 
+/**
+ * Note: with the linux tun/tap device, we could probably add the channel to the selector directly
+ * in the client and use a single thread, however, the Android tun/tap doesn't easily adapt to a
+ * SelectableChannel which is why I'm doing things this way.
+ */
 class TunTapDevice {
     companion object {
         // the function call for configuring a TUN interface in ioctl from if_tun.h
@@ -17,12 +39,26 @@ class TunTapDevice {
 
         // from if_tun.h - tells the kernel to not add packet information header before the packet
         private const val FLAGS_IFF_NO_PI: Short = 0x1000
+
+        private const val MAX_RECEIVE_BUFFER_SIZE = 1500 // max amount we can recv in one read (should be the MTU or bigger probably)
     }
 
     private val logger = LoggerFactory.getLogger(javaClass)
     private lateinit var nativeSocketChannel: NativeSocketChannel
 
+    private val isRunning = AtomicBoolean(false)
+    private lateinit var selector: Selector
+    private lateinit var selectorJob: CompletableJob
+    private lateinit var selectorScope: CoroutineScope
+    private val changeRequests = LinkedList<ChangeRequest>()
+    private val outgoingQueue = LinkedBlockingDeque<ByteBuffer>() // queue of data to be read
+    private val incomingQueue = LinkedBlockingDeque<ByteBuffer>() // queue of data to be written
+
     fun open() {
+        if (isRunning.get()) {
+            logger.error("Already opened")
+            return
+        }
         val fd = LibC.open("/dev/net/tun", O_RDWR)
         if (fd < 0) {
             throw RuntimeException("Error opening TUN/TAP device: $fd ${Native.getLastError()}")
@@ -39,36 +75,110 @@ class TunTapDevice {
             throw RuntimeException("Error creating TUN/TAP device: $tunCreateResult ${Native.getLastError()}")
         }
         logger.debug("Created TUN/TAP device")
+        isRunning.set(true)
         nativeSocketChannel = NativeSocketChannel(fd)
+
+        // if we don't put this into non-blocking, it gets stuck on the read even when we try to
+        // close, so we use a selector instead
+        nativeSocketChannel.configureBlocking(false)
+
+        selector = NativeSelectorProvider.getInstance().openSelector()
+        selectorJob = SupervisorJob()
+        selectorScope = CoroutineScope(Dispatchers.IO + selectorJob)
+        selectorScope.launch {
+            selectorLoop()
+        }
     }
 
+    private fun selectorLoop() {
+        nativeSocketChannel.register(selector, OP_READ)
+
+        while (isRunning.get()) {
+            synchronized(changeRequests) {
+                for (changeRequest in changeRequests) {
+                    when (changeRequest.type) {
+                        REGISTER -> {
+                            logger.debug("Processing REGISTER: ${changeRequest.ops}")
+                            changeRequest.channel.register(selector, changeRequest.ops)
+                        }
+                        CHANGE_OPS -> {
+                            logger.debug("Processing CHANGE_OPS: ${changeRequest.ops}")
+                            val key = changeRequest.channel.keyFor(selector)
+                            key.interestOps(changeRequest.ops)
+                        }
+                    }
+                }
+                changeRequests.clear()
+            }
+
+            try {
+                val numKeys = selector.select()
+                // we won't get any keys if we wakeup the selector before we select
+                // (ie, when we make changes to the keys or interest-ops)
+                if (numKeys > 0) {
+                    val selectedKeys = selector.selectedKeys()
+                    val keyStream = selectedKeys.parallelStream()
+                    keyStream.forEach {
+                        if (it.isReadable && it.isValid) {
+                            val recvBuffer = ByteBuffer.allocate(MAX_RECEIVE_BUFFER_SIZE)
+                            nativeSocketChannel.read(recvBuffer)
+                            recvBuffer.flip()
+                            outgoingQueue.add(recvBuffer)
+                        }
+                        if (it.isWritable && it.isValid) {
+                            if (incomingQueue.isNotEmpty()) {
+                                val buffer = incomingQueue.take()
+                                while (buffer.hasRemaining()) {
+                                    nativeSocketChannel.write(buffer)
+                                }
+                            } else {
+                                it.interestOps(OP_READ)
+                            }
+                        }
+                    }
+                    selectedKeys.clear()
+                }
+            } catch (e: Exception) {
+                logger.warn("Exception on select, probably shutting down: $e")
+                break
+            }
+        }
+        selectorJob.complete()
+    }
+
+    /**
+     * This should not be called from multiple threads, or each thread will get different data.
+     */
     fun read(
         readBytes: ByteArray,
         bytesToRead: Int,
     ): Int {
-        // why are we doing this and not using nativeSocketChannel read?
-        // return LibC.read(nativeSocketChannel.fd, readBytes, NativeLong(bytesToRead.toLong()))
-        val buffer = ByteBuffer.allocate(bytesToRead)
-        val result = nativeSocketChannel.read(buffer)
-        logger.debug("Read $result bytes from nativesocket")
-        if (result > 0) {
-            buffer.rewind()
-            buffer.get(readBytes)
-            buffer.clear()
-        } else {
-            logger.debug("Read $result bytes")
-        }
-        return result
+        // this will block until the selector puts something here, to unblock when we're shutting
+        // down, just stick an empty buffer in the outgoing queue
+        val buffer = outgoingQueue.take()
+        val bytesToTake = min(bytesToRead, buffer.remaining())
+        logger.debug(
+            "About to read: $bytesToTake bytes from buffer, position: ${buffer.position()}, limit: ${buffer.limit()}, remaining: ${buffer.remaining()}",
+        )
+        buffer.get(readBytes, 0, bytesToTake)
+        return bytesToTake
     }
 
     fun write(writeBytes: ByteArray) {
-        val writeBuffer = ByteBuffer.wrap(writeBytes)
-        while (writeBuffer.hasRemaining()) {
-            nativeSocketChannel.write(writeBuffer)
+        incomingQueue.add(ByteBuffer.wrap(writeBytes))
+        synchronized(changeRequests) {
+            changeRequests.add(ChangeRequest(nativeSocketChannel, CHANGE_OPS, OP_WRITE))
         }
+        selector.wakeup()
     }
 
     fun close() {
+        isRunning.set(false)
+        selector.close()
         nativeSocketChannel.close()
+        outgoingQueue.put(ByteBuffer.allocate(0)) // unstick any blocking reads
+        runBlocking {
+            selectorJob.join()
+        }
     }
 }

--- a/core/src/main/kotlin/com/jasonernst/kanonproxy/KAnonProxy.kt
+++ b/core/src/main/kotlin/com/jasonernst/kanonproxy/KAnonProxy.kt
@@ -65,6 +65,7 @@ class KAnonProxy(
 
     companion object {
         const val STALE_SESSION_MS = 5000L
+        const val DEFAULT_PORT = 8080
     }
 
     fun start() {

--- a/server/src/main/kotlin/com/jasonernst/kanonproxy/ProxySession.kt
+++ b/server/src/main/kotlin/com/jasonernst/kanonproxy/ProxySession.kt
@@ -1,6 +1,9 @@
 package com.jasonernst.kanonproxy
 
 import com.jasonernst.knet.SentinelPacket
+import com.jasonernst.packetdumper.AbstractPacketDumper
+import com.jasonernst.packetdumper.DummyPacketDumper
+import com.jasonernst.packetdumper.ethernet.EtherType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -11,6 +14,7 @@ import org.slf4j.LoggerFactory
 import java.net.DatagramPacket
 import java.net.DatagramSocket
 import java.net.InetSocketAddress
+import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicBoolean
 
 class ProxySession(
@@ -18,6 +22,7 @@ class ProxySession(
     private val kAnonProxy: KAnonProxy,
     private val socket: DatagramSocket,
     private val sessionManager: ProxySessionManager,
+    private val packetDumper: AbstractPacketDumper = DummyPacketDumper,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val readFromProxyJob = SupervisorJob()
@@ -46,6 +51,7 @@ class ProxySession(
             }
             // logger.debug("Received response from proxy for client: $clientAddress, sending datagram back")
             val buffer = response.toByteArray()
+            packetDumper.dumpBuffer(ByteBuffer.wrap(buffer), etherType = EtherType.DETECT)
             val datagramPacket = DatagramPacket(buffer, buffer.size, clientAddress)
             try {
                 socket.send(datagramPacket)

--- a/server/src/main/kotlin/com/jasonernst/kanonproxy/Server.kt
+++ b/server/src/main/kotlin/com/jasonernst/kanonproxy/Server.kt
@@ -5,6 +5,7 @@ import com.jasonernst.icmp.linux.IcmpLinux
 import com.jasonernst.knet.Packet
 import com.jasonernst.packetdumper.AbstractPacketDumper
 import com.jasonernst.packetdumper.DummyPacketDumper
+import com.jasonernst.packetdumper.ethernet.EtherType
 import com.jasonernst.packetdumper.serverdumper.PcapNgTcpServerPacketDumper
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineScope
@@ -107,15 +108,15 @@ class Server(
             stream.put(buffer, 0, packet.length)
             stream.flip()
             val packets = Packet.parseStream(stream)
-//            for (packet in packets) {
-//                logger.debug("From Client: packet $packet")
-//            }
+            for (p in packets) {
+                packetDumper.dumpBuffer(ByteBuffer.wrap(p.toByteArray()), etherType = EtherType.DETECT)
+            }
             val clientAddress = InetSocketAddress(packet.address, packet.port)
             kAnonProxy.handlePackets(packets, clientAddress)
             var newSession = false
             sessions.getOrPut(clientAddress) {
                 newSession = true
-                val session = ProxySession(clientAddress, kAnonProxy, socket, this)
+                val session = ProxySession(clientAddress, kAnonProxy, socket, this, packetDumper)
                 session.start()
                 session
             }

--- a/server/src/main/kotlin/com/jasonernst/kanonproxy/Server.kt
+++ b/server/src/main/kotlin/com/jasonernst/kanonproxy/Server.kt
@@ -6,7 +6,6 @@ import com.jasonernst.knet.Packet
 import com.jasonernst.packetdumper.AbstractPacketDumper
 import com.jasonernst.packetdumper.DummyPacketDumper
 import com.jasonernst.packetdumper.serverdumper.PcapNgTcpServerPacketDumper
-import com.jasonernst.packetdumper.serverdumper.PcapNgTcpServerPacketDumper.Companion.DEFAULT_PORT
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -24,7 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 class Server(
     icmp: Icmp,
-    private val port: Int = 8080,
+    private val port: Int = KAnonProxy.DEFAULT_PORT,
     private val packetDumper: AbstractPacketDumper = DummyPacketDumper,
     protector: VpnProtector = DummyProtector,
 ) : ProxySessionManager {
@@ -44,10 +43,10 @@ class Server(
         @JvmStatic
         fun main(args: Array<String>) {
             // listen on one port higher so we don't conflict with the client
-            val packetDumper = PcapNgTcpServerPacketDumper(listenPort = DEFAULT_PORT + 1)
+            val packetDumper = PcapNgTcpServerPacketDumper(listenPort = PcapNgTcpServerPacketDumper.DEFAULT_PORT + 1)
             val server =
                 if (args.isEmpty()) {
-                    println("Using default port: 8080")
+                    println("Using default port: ${KAnonProxy.DEFAULT_PORT}")
                     Server(IcmpLinux)
                 } else {
                     if (args.size != 1) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
     }
 }
 rootProject.name = "kanonproxy"
-include("core")
-include("server")
-include("client")
+include(":core")
+include(":server")
+include(":client")
 include(":android")


### PR DESCRIPTION
- The android app I'm targetting with this requires that a channel be used rather than a socket.
- I also updated the client to use non-blocking IO
- The linux tun/tap device was also set to use non-blocking IO because without it, it gets stuck on the read call and can't be shutdown without a pkill -9